### PR TITLE
feat: set default luarocks cache to `stdpath(cache)/luarocks`

### DIFF
--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -262,6 +262,7 @@ local function mk_luarocks_config()
             },
         },
         arch = arch,
+        local_cache = vim.fs.joinpath(vim.fn.stdpath("cache") --[[@as string]], "luarocks"),
     }
     local luarocks_config = vim.tbl_deep_extend("force", default_luarocks_config, opts.luarocks_config or {})
 

--- a/spec/luarocks_config_spec.lua
+++ b/spec/luarocks_config_spec.lua
@@ -28,6 +28,7 @@ describe("luarocks config", function()
         assert.same({
             lua_version = "5.1",
             external_deps_dirs = external_deps_dirs,
+            local_cache = vim.fs.joinpath(vim.fn.stdpath("cache") --[[@as string]], "luarocks"),
             rocks_trees = {
                 { name = "rocks.nvim", root = tempdir },
             },


### PR DESCRIPTION
See #578.

Problem: On some systems, the `/tmp` directory is limited in size. LuaRocks can contribute to it getting filled.

Solution: Use Nvim's `stdpath("cache")`.
